### PR TITLE
raise error if google returns request_denied

### DIFF
--- a/R/drive_time.R
+++ b/R/drive_time.R
@@ -187,7 +187,15 @@ drive_time <- function(address, dest, auth="standard_api", privkey=NULL,
 
 
 	json <- placement::pull_geo_data(togoogle, tmout=10, messages=messages)
-
+	
+	#raise error if response is denied
+	if (json[[1]]$status == 'REQUEST_DENIED') {
+        	stop(paste0(
+          		"Request sent to Google, but response returned REQUEST_DENIED.  Error details:\n", 
+          		json[[1]]$error_message
+        	))
+	}
+		
 	coord <- t(vapply(json, function(x) {
 		if(!is.null(x$status)){
 			if(x$status=="OK"){


### PR DESCRIPTION
Hi @DerekYves, thanks again for all the hard work you've done here.

Initially my requests to drive_time were failing with a somewhat cryptic vapply error:
```
Sending locations (n=1) to Google for distance calculation...
Error in vapply(json, function(x) { : values must be length 11,
 but FUN(X[[1]]) result is length 0
```

I dug into the internals and figured out from the response Google was returning that I actually needed to enable another API above/beyond Maps - the [Distance Matrix API](https://console.developers.google.com/apis/api/distance_matrix_backend/).  The error above makes sense in that context - `drive_time` is trying to work with the valid json output, but the response is an error, not a successful request.

Once I turned on that API everything worked as expected.  This PR simply raises the error to the user so that they get a more informative error that will help them understand what might be going wrong with their request.